### PR TITLE
Migrate to SQLite

### DIFF
--- a/mudlet/profiles/newbot/scripts/edit_me.lua
+++ b/mudlet/profiles/newbot/scripts/edit_me.lua
@@ -42,8 +42,10 @@ end
 
 function openDB()
 	lastAction = "Open Database"
-	env = mysql.mysql()
-	conn = env:connect(botDB, botDBUser, botDBPass)
+	local sqliteDriver = require "luasql.sqlite3"
+	env = luasql.sqlite3()
+	
+	conn = env:connect(getMudletHomeDir() .. "/Database_" .. botDB .. ".db")
 
 	conn:execute("INSERT INTO memRestrictedItems (select * from restrictedItems)")
 	conn:execute("INSERT INTO memLottery (select * from lottery)")
@@ -51,5 +53,5 @@ end
 
 
 function openBotsDB()
-	connBots = env:connect(botsDB, botsDBUser, botsDBPass)
+	connBots = env:connect(getMudletHomeDir() .. "/Database_" .. botsDB .. ".db")
 end

--- a/mudlet/profiles/newbot/scripts/load_lua_tables.lua
+++ b/mudlet/profiles/newbot/scripts/load_lua_tables.lua
@@ -13,7 +13,7 @@ debug = false
 function loadServer()
 	local temp, cursor, errorString, row, rows
 	
---	debug = false
+	-- debug = true
 	calledFunction = "loadServer"
 	
 	if (debug) then display("debug loadServer line " .. debugger.getinfo(1).currentline .. "\n") end	
@@ -27,10 +27,9 @@ function loadServer()
 		server = {}
 	end
 
-	cursor,errorString = conn:execute("select * from server")
-	rows = tonumber(cursor:numrows())
+	local cursor,errorString = conn:execute("select * from server")
 	if (debug) then display("debug loadServer line " .. debugger.getinfo(1).currentline .. "\n") end	
-	if rows == 0 then
+	if cursor and cursor ~= 0 then
 		if (debug) then display("debug loadServer line " .. debugger.getinfo(1).currentline .. "\n") end		
 		initServer()
 		if (debug) then display("debug loadServer line " .. debugger.getinfo(1).currentline .. "\n") end	
@@ -149,10 +148,10 @@ function loadShopCategories()
 	shopCategories = {}
 	getTableFields("shopCategories")
 
-	cursor,errorString = conn:execute("select * from shopCategories")
+	local cursor,errorString = conn:execute("select * from shopCategories")
 
 	-- add the misc category so it always exists
-	if cursor:numrows() > 0 then
+	if type(cursor) == "userdata" then
 		shopCategories["misc"] = {}
 		shopCategories["misc"].idx = 1
 		shopCategories["misc"].code = "misc"
@@ -258,8 +257,8 @@ function loadLocations(loc)
 	
 	if loc == nil then locations = {} end	
 
-	cursor,errorString = conn:execute("select * from locations")
-	row = cursor:fetch({}, "a")
+	local cursor,errorString = conn:execute("select * from locations")
+	local row = cursor:fetch({}, "a")
 	
 	if row then
 		cols = cursor:getcolnames()		
@@ -665,7 +664,7 @@ function loadGimmeZombies()
 	row = cursor:fetch({}, "a")	
 
 	if row then
-		cols = cursor:getcolnames()		
+		cols = cursor:getcolnames()
 	end	
 	
 	while row do		
@@ -673,8 +672,8 @@ function loadGimmeZombies()
 		gimmeZombies[idx] = {}
 
 		for k,v in pairs(cols) do						
-			for n,m in pairs(row) do	
-				if n == _G["gimmeZombiesFields"][v].field then					
+			for n,m in pairs(row) do
+				if _G["gimmeZombiesFields"][v] and n == _G["gimmeZombiesFields"][v].field then					
 					if _G["gimmeZombiesFields"][v].type == "var" or _G["gimmeZombiesFields"][v].type == "big" then
 						gimmeZombies[idx][n] = m
 					end

--- a/mudlet/profiles/newbot/scripts/save_db_tables.lua
+++ b/mudlet/profiles/newbot/scripts/save_db_tables.lua
@@ -80,7 +80,7 @@ function getServerFields()
 	--function inspect the server table and store field names and types
 	serverFields = {}
 
-	cursor,errorString = conn:execute("SHOW FIELDS FROM server")
+	cursor,errorString = conn:execute("PRAGMA table_info(server)")
 	row = cursor:fetch({}, "a")
 	while row do
 		field = row.Field
@@ -167,7 +167,7 @@ function getPlayerFields()
 	--function inspect the player table and store field names and types
 	playerFields = {}
 
-	cursor,errorString = conn:execute("SHOW FIELDS FROM players")
+	local cursor,errorString = conn:execute("PRAGMA table_info(players)")
 	row = cursor:fetch({}, "a")
 	while row do
 		field = row.Field
@@ -288,7 +288,7 @@ function getTableFields(table)
 
 	_G[tbl] = {}
 
-	cursor,errorString = conn:execute("SHOW FIELDS FROM " .. table)
+	local cursor,errorString = conn:execute("PRAGMA table_info(" .. table .. ")")
 	row = cursor:fetch({}, "a")
 	
 	while row do


### PR DESCRIPTION
MySQL makes the entire thing a pain to use in Windows as you've discovered and it's also massive overkill for the project - sqlite is far better suited for this task. It's what Google Chrome, Firefox, and [anyone else](https://www.sqlite.org/famous.html) from Airbus to Microsoft who needs a database locally uses.

First, to get started, migrate mysql data to sqlite. Get [mysql2sqlite](https://github.com/dumblob/mysql2sqlite) script, then:

1. export mysql with:
> mysqldump -u root --password="password-here" --skip-extended-insert --compact --databases database-name-here > database-name-here-mysql.sql
1. convert it to sqlite using the script: 
> ./mysql2sqlite.sh database-name-mysql.sql > database-name-sqlite.sql
1. load it up into sqlite with:
> sqlite3 /home/vadi/.config/mudlet/profiles/profile-name-here/Database-database-name-here.db
> .read /location/to/database-name-here-sqlite.sql 

Here's how successful output looks like:

```code
vadi@volga:~$ mysqldump -u root --password="password-here" --skip-extended-insert --compact --databases vadi > vadi-mysql.sql
mysqldump: [Warning] Using a password on the command line interface can be insecure.
vadi@volga:~$ ./mysql2sqlite.sh vadi-mysql.sql > vadi-sqlite.sql
vadi@volga:~$ sqlite3 /home/vadi/.config/mudlet/profiles/Vadi/vadi.db
SQLite version 3.11.0 2016-02-15 17:29:24
Enter ".help" for usage hints.
sqlite> .read /home/vadi/vadi-sqlite.sql 
memory
sqlite> .quit
vadi@volga:~$ 
```

Do that for ``bot`` and ``bots`` db. Then checkout the code in this PR and try loading Mudlet up.

I got the code to the point where it loads without errors - I'm not familiar at all with the program so I can't tell if it's doing the right thing or not. Haven't checked any functionality either for that reason.